### PR TITLE
feat: line init && BREAKING_CHANGE api `fill` -> `render`

### DIFF
--- a/playground/line.html
+++ b/playground/line.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  <canvas id="canvas" style="background-color: #ccc"></canvas>
+  <script type="module">
+    import { CanvasEngine, Line } from '../dist/index.mjs'
+    const engine = new CanvasEngine({
+      w: 300,
+      h: 300,
+      target: '#canvas',
+    })
+
+    const line = new Line({
+      x: 10,
+      y: 10,
+    })
+
+    line.move(100, 75).move(100, 25).move(-200, -25).move(129, 290)
+    engine.render(line, {
+      color: 'red',
+      mode: 'stroke',
+    })
+  </script>
+</body>
+</html>

--- a/src/act.ts
+++ b/src/act.ts
@@ -1,39 +1,39 @@
-import type { CanvasEngine, FillOptions } from "./canvasEngine";
-import { ShapeType } from "./types/shape";
-import type { ActShape } from "./types/shape";
-import { Noop } from "./types/event";
+import type { CanvasEngine, RenderOptions } from './canvasEngine'
+import { ShapeType } from './types/shape'
+import type { ActShape } from './types/shape'
+import type { Noop } from './types/event'
 
 export interface ActOptions {
-  x: number;
-  y: number;
-  radius: number;
-  zIndex: number;
+  x: number
+  y: number
+  radius: number
+  zIndex: number
 }
 
 export class Act {
-  path2D: Path2D = new Path2D();
-  id = Symbol("Act");
-  figureInformation!: ActShape;
-  noop: Noop = {};
-  zIndex: number = -1
+  path2D: Path2D = new Path2D()
+  id = Symbol('Act')
+  figureInformation!: ActShape
+  noop: Noop = {}
+  zIndex = -1
   constructor(options: ActOptions) {
-    this.injectFigureInformation(options);
-    this.machiningGraphics(options);
+    this.injectFigureInformation(options)
+    this.machiningGraphics(options)
     this.zIndex = options.zIndex || -1
   }
 
   machiningGraphics(options: ActOptions) {
-    const { x, y, radius } = options;
-    this.path2D.arc(x, y, radius, 0, Math.PI * 2);
+    const { x, y, radius } = options
+    this.path2D.arc(x, y, radius, 0, Math.PI * 2)
   }
 
-  fill(canvasEngine: CanvasEngine, opt: FillOptions) {
-    const { color } = opt;
-    canvasEngine.ctx.fillStyle = color || "";
-    canvasEngine.ctx.fill(this.path2D);
+  render(canvasEngine: CanvasEngine, opt: RenderOptions) {
+    const { color } = opt
+    canvasEngine.ctx.fillStyle = color || ''
+    canvasEngine.ctx.fill(this.path2D)
   }
 
   injectFigureInformation(options: ActOptions) {
-    this.figureInformation = { ...options, shape: ShapeType.Act };
+    this.figureInformation = { ...options, shape: ShapeType.Act }
   }
 }

--- a/src/canvasEngine.ts
+++ b/src/canvasEngine.ts
@@ -1,90 +1,94 @@
-import { Rect, RectOptions } from "./rect";
-import { EventFn, EventName } from "./types/event";
-import { baseShape } from "./types/shape";
+import type { Rect } from './rect'
+import type { EventFn, EventName } from './types/event'
+import type { baseShape } from './types/shape'
 
 // todo
 // 移动元素
 // 切换图层
 
 export interface CanvasEngineProps {
-  w?: string;
-  h?: string;
-  canvasTarget?: string;
+  w?: string
+  h?: string
+  canvasTarget?: string
 }
 
 export interface DrawDependencyGraphMap {
-  id: symbol;
-  path2D: Path2D;
+  id: symbol
+  path2D: Path2D
   // todo 这个类型要换
-  figureInformation: baseShape;
+  figureInformation: baseShape
 }
 
-export interface FillOptions {
-  color?: string;
+export interface RenderOptions {
+  color?: string
+  mode?: 'fill' | 'stroke'
 }
 
 export class CanvasEngine {
-  public canvasHeight!: number;
-  public canvasWidth!: number;
+  public canvasHeight!: number
+  public canvasWidth!: number
   // 绘画图
-  private drawDependencyGraphsMap: Map<symbol, DrawDependencyGraphMap> =
-    new Map();
+  private drawDependencyGraphsMap: Map<symbol, DrawDependencyGraphMap>
+    = new Map()
+
   // canvas dom
-  private rawCanvasDom: HTMLCanvasElement;
+  private rawCanvasDom: HTMLCanvasElement
   // canvas ctx
-  public ctx!: CanvasRenderingContext2D;
+  public ctx!: CanvasRenderingContext2D
   // 事件map
-  public eventsMap: Map<string, Set<EventFn>> = new Map();
+  public eventsMap: Map<string, Set<EventFn>> = new Map()
   // 渲染队列
-  private renderQueue: { graphical: Rect; options: FillOptions }[] = [];
+  private renderQueue: { graphical: Rect; options: RenderOptions }[] = []
 
   constructor(public options: CanvasEngineProps) {
-    this.rawCanvasDom = this.initCanvasSize(options);
-    this.initCtx();
+    this.rawCanvasDom = this.initCanvasSize(options)
+    this.initCtx()
   }
 
   private initCanvasSize(options: CanvasEngineProps) {
-    const { w, h, canvasTarget } = options;
+    const { w, h, canvasTarget } = options
     const canvasDom = document.getElementById(
-      canvasTarget || "canvas"
-    ) as HTMLCanvasElement;
+      canvasTarget || 'canvas',
+    ) as HTMLCanvasElement
 
     if (canvasDom) {
-      canvasDom.setAttribute("width", w || "500");
-      canvasDom.setAttribute("height", h || "500");
-      this.canvasWidth = Number(w || "500");
-      this.canvasHeight = Number(h || "500");
-    } else {
-      throw new Error("请选择正确的 canvas id 获取dom元素");
+      canvasDom.setAttribute('width', w || '500')
+      canvasDom.setAttribute('height', h || '500')
+      this.canvasWidth = Number(w || '500')
+      this.canvasHeight = Number(h || '500')
     }
-    return canvasDom;
+    else {
+      throw new Error('请选择正确的 canvas id 获取dom元素')
+    }
+    return canvasDom
   }
+
   private sortRenderQueue() {
     this.renderQueue.sort((a, b) => {
-      return a.graphical.zIndex - b.graphical.zIndex;
-    });
+      return a.graphical.zIndex - b.graphical.zIndex
+    })
   }
+
   private initCtx() {
-    this.ctx = this.rawCanvasDom.getContext("2d") as CanvasRenderingContext2D;
+    this.ctx = this.rawCanvasDom.getContext('2d') as CanvasRenderingContext2D
   }
 
   public getCanvasDom(): HTMLCanvasElement {
-    return this.rawCanvasDom;
+    return this.rawCanvasDom
   }
 
-  public fill(
+  public render(
     graphical: Rect,
-    options: FillOptions,
-    isReload: boolean = false
+    options: RenderOptions,
+    isReload = false,
   ) {
-    // graphical.fill(this, options);
     if (!isReload) {
-      this.drawDependencyGraphsMap.set(graphical.id, graphical);
+      this.drawDependencyGraphsMap.set(graphical.id, graphical)
       this.renderQueue.push({
         graphical,
         options,
-      });
-      this.reload();
+      })
+      this.reload()
     }
   }
 
@@ -93,72 +97,75 @@ export class CanvasEngine {
       const isHas = this.ctx.isPointInPath(
         graphical.path2D,
         e.clientX,
-        e.clientY
-      );
-      if (isHas) {
-        fn(e);
-      }
-    };
+        e.clientY,
+      )
+      if (isHas)
+        fn(e)
+    }
 
     if (this.eventsMap.has(eventType)) {
-      const eventSet = this.eventsMap.get(eventType);
-      eventSet?.add(noop);
-    } else {
-      this.eventsMap.set(eventType, new Set([noop]));
+      const eventSet = this.eventsMap.get(eventType)
+      eventSet?.add(noop)
+    }
+    else {
+      this.eventsMap.set(eventType, new Set([noop]))
       this.rawCanvasDom.addEventListener(eventType, (e) => {
-        const events = this.eventsMap.get(eventType);
+        const events = this.eventsMap.get(eventType)
         events?.forEach((fn) => {
-          fn(e);
-        });
-      });
+          fn(e)
+        })
+      })
     }
 
-    let eventsNoopSet = graphical.noop[eventType];
-    if (!eventsNoopSet) {
-      eventsNoopSet = graphical.noop[eventType] = new Set();
-    }
-    eventsNoopSet.add(noop);
+    let eventsNoopSet = graphical.noop[eventType]
+    if (!eventsNoopSet)
+      eventsNoopSet = graphical.noop[eventType] = new Set()
+
+    eventsNoopSet.add(noop)
 
     return () => {
-      const eventSet = this.eventsMap.get(eventType);
-      eventSet?.delete(noop);
-    };
+      const eventSet = this.eventsMap.get(eventType)
+      eventSet?.delete(noop)
+    }
   }
+
   public clear(graphical: Rect) {
     const index = this.renderQueue.findIndex(
-      (it) => it.graphical.id === graphical.id
-    );
-    if (index === -1) return;
-    this.renderQueue.splice(index, 1);
-    this.emptyEvents(graphical);
-    this.reload();
+      it => it.graphical.id === graphical.id,
+    )
+    if (index === -1) return
+    this.renderQueue.splice(index, 1)
+    this.emptyEvents(graphical)
+    this.reload()
   }
+
   public emptyEvents(graphical: Rect) {
-    const { noop } = graphical;
+    const { noop } = graphical
     Object.keys(noop).forEach((eventName) => {
-      this.clearEvents(graphical, eventName as EventName);
-    });
+      this.clearEvents(graphical, eventName as EventName)
+    })
   }
+
   public clearEvents(graphical: Rect, eventType: EventName) {
-    const { noop } = graphical;
-    const selfEventSet = noop[eventType];
-    const eventSet = this.eventsMap.get(eventType);
-    if (!selfEventSet || !eventSet) return;
+    const { noop } = graphical
+    const selfEventSet = noop[eventType]
+    const eventSet = this.eventsMap.get(eventType)
+    if (!selfEventSet || !eventSet) return
     selfEventSet.forEach((fn) => {
-      eventSet.delete(fn);
-    });
+      eventSet.delete(fn)
+    })
   }
+
   public reload() {
-    this.clearView();
-    this.sortRenderQueue();
+    this.clearView()
+    this.sortRenderQueue()
     this.renderQueue.forEach((render) => {
-      render.graphical.fill(this, render.options);
-      // this.fill(render.graphical, render.options, true);
-    });
+      render.graphical.render(this, render.options)
+    })
   }
 
   public clearView() {
-    this.ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
+    this.ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight)
   }
 
   public modifyShapeLayer(graphical: Rect, zIndex: number) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './canvasEngine'
 export * from './rect'
 export * from './act'
+export * from './line'

--- a/src/line.ts
+++ b/src/line.ts
@@ -1,0 +1,63 @@
+import type { CanvasEngine, RenderOptions } from './canvasEngine'
+import type { LineShape } from './types/shape'
+import { ShapeType } from './types/shape'
+
+export interface LineOptions {
+  x: number
+  y: number
+  thickness?: number
+  zIndex?: number
+}
+
+export class Line {
+  figureInformation = {} as LineShape
+  constructor(options: LineOptions) {
+    this.injectFigureInformation(options)
+  }
+
+  injectFigureInformation({ x, y, thickness = 1, zIndex = -1 }: LineOptions) {
+    this.figureInformation = {
+      x,
+      y,
+      end: { x, y },
+      thickness,
+      zIndex,
+      shape: ShapeType.Line,
+      track: [],
+    }
+  }
+
+  move(toX: number, toY: number) {
+    const { x: nowX, y: nowY } = this.figureInformation.end
+    const track = { x: nowX + toX, y: nowY + toY }
+    this.figureInformation.end = track
+    this.figureInformation.track.push(track)
+    return this
+  }
+
+  /**
+   * line fill function
+   *
+   * @param engine canvasEngine
+   * @param fillOptions fillOptions
+   * @description 若前后不闭合，采用 stroke 绘制， 反之采用 fill 绘制
+   */
+  render(engine: CanvasEngine, { color = '', mode = 'fill' }: RenderOptions) {
+    engine.ctx.beginPath()
+    const len = this.figureInformation.track.length
+    for (let i = 0; i < len; i++) {
+      const { x, y } = this.figureInformation.track[i]
+      engine.ctx.lineTo(x, y)
+    }
+    if (mode === 'fill') {
+      engine.ctx.fillStyle = color
+      engine.ctx.fill()
+    }
+    else if (mode === 'stroke') {
+      engine.ctx.strokeStyle = color
+      engine.ctx.stroke()
+    }
+
+    engine.ctx.closePath()
+  }
+}

--- a/src/rect.ts
+++ b/src/rect.ts
@@ -1,44 +1,44 @@
-import { FillOptions } from "./canvasEngine";
-import { CanvasEngine } from "./canvasEngine";
-import { Noop } from "./types/event";
-import { RectShape, ShapeType } from "./types/shape";
+import type { CanvasEngine, RenderOptions } from './canvasEngine'
+import type { Noop } from './types/event'
+import type { RectShape } from './types/shape'
+import { ShapeType } from './types/shape'
 
 export interface RectOptions {
-  x: number;
-  y: number;
-  shape: "";
-  w: number;
-  h: number;
-  zIndex: number;
+  x: number
+  y: number
+  shape: ''
+  w: number
+  h: number
+  zIndex: number
 }
 
 export class Rect {
-  path2D: Path2D = new Path2D();
-  id: symbol = Symbol();
-  figureInformation!: RectShape;
-  noop: Noop = {};
-  zIndex: number = -1;
+  path2D: Path2D = new Path2D()
+  id = Symbol('Rect')
+  figureInformation!: RectShape
+  noop: Noop = {}
+  zIndex = -1
   constructor(options: RectOptions) {
-    this.machiningGraphics(options);
-    this.injectFigureInformation(options);
-    this.zIndex = options.zIndex || -1;
+    this.machiningGraphics(options)
+    this.injectFigureInformation(options)
+    this.zIndex = options.zIndex || -1
   }
 
   private machiningGraphics(options: RectOptions) {
-    const { x, y, w, h } = options;
-    this.path2D.rect(x, y, w, h);
+    const { x, y, w, h } = options
+    this.path2D.rect(x, y, w, h)
   }
 
-  public fill(canvasEngine: CanvasEngine, options: FillOptions) {
-    const { color } = options;
-    canvasEngine.ctx.fillStyle = color || "";
-    canvasEngine.ctx.fill(this.path2D);
+  public render(canvasEngine: CanvasEngine, options: RenderOptions) {
+    const { color } = options
+    canvasEngine.ctx.fillStyle = color || ''
+    canvasEngine.ctx.fill(this.path2D)
   }
 
   private injectFigureInformation(options: RectOptions) {
     this.figureInformation = {
       ...options,
       shape: ShapeType.Rect,
-    };
+    }
   }
 }

--- a/src/types/shape.ts
+++ b/src/types/shape.ts
@@ -1,17 +1,18 @@
 export enum ShapeType {
   Rect,
   Act,
+  Line,
 }
 
 export interface Size {
-  w: number;
-  h: number;
+  w: number
+  h: number
 }
 
 export interface baseShape {
-  shape: ShapeType;
-  x: number;
-  y: number;
+  shape: ShapeType
+  x: number
+  y: number
 }
 
 export interface RectShape extends baseShape, Size {}
@@ -21,5 +22,20 @@ export interface RectShape extends baseShape, Size {}
  * @param {number} radius 半径
  */
 export interface ActShape extends baseShape {
-  radius: number;
+  radius: number
+}
+
+/**
+ * @start {number} x, y 起点
+ * @end {number} x, y 终点
+ * @thickness {number} 线宽
+ * @color {string} 线条颜色
+ * @zIndex {number} 层级
+ * @track {{x:number, y:number}[]} 轨迹路线图
+ */
+export interface LineShape extends baseShape {
+  end: { x: number; y: number }
+  thickness: number
+  zIndex: number
+  track: { x: number; y: number }[]
 }


### PR DESCRIPTION
# 做了以下几件事情：

- 创建 Line 类，用于支持描线功能
- 所有 Line 实例拥有成员方法 `move` 接收一个 x 和 y，表示需要移动的距离，注意这里不是要移动到哪里，而是需要移动多少，目的是降低使用者的心智负担，不用频繁去计算终点，只需要关注每次移动多少就可以了

# BEAKING_CHANGE

核心 api 变动！！

- 为了支持两种渲染模式，将 `fill` 函数修改为 `render`, 将 `FillOptions` 修改为 `RenderOptions`
- 增加 `RenderOptions.mode` 支持 `fill` 和 `stroke` 两种模式